### PR TITLE
Fix: 일시 정지 반복 시, 오디오가 밀리는 버그 수정

### DIFF
--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -48,6 +48,8 @@ public class AudioManager : MonoBehaviour
     }
     public State state = State.Stop;
 
+    private float savedAudioTimeForPause { get; set; }
+
     void Awake()
     {
         if (instance == null)
@@ -77,13 +79,24 @@ public class AudioManager : MonoBehaviour
     public void Pause()
     {
         state = State.Paused;
+        savedAudioTimeForPause = progressTime;
         audioSource.Pause();
     }
 
     public void UnPause()
     {
         state = State.Unpaused;
-        audioSource.UnPause();
+
+        if (audioSource.clip != null)
+        {
+            progressTime = savedAudioTimeForPause;
+            audioSource.UnPause();
+            Debug.Log("Audio unpaused successfully at time: " + audioSource.time);
+        }
+        else
+        {
+            Debug.LogError("Audio clip is null. Cannot unpause.");
+        }
     }
 
     public void Stop()

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -122,7 +122,7 @@ public class GameManager : MonoBehaviour
     {
         if (state == GameState.Game)
         {
-            Time.timeScale = 0;
+            Time.timeScale = 0f;
             isPaused = true;
             isPlaying = false;
 
@@ -150,9 +150,6 @@ public class GameManager : MonoBehaviour
             StartCoroutine(SheetLoader.Instance.WebGLLoadSheet(title));
         }
 
-        // 노트 Gen 끄기
-        NoteGenerator.Instance.PauseGen();
-
         // 음악 멈추기
         AudioManager.Instance.Pause();
     }
@@ -165,9 +162,6 @@ public class GameManager : MonoBehaviour
 
         // Pause UI 끄기
         canvases[(int)Canvas.Pause].SetActive(false);
-
-        // Note 다시 생성
-        NoteGenerator.Instance.StartGen();
 
         // Audio 다시 재싱
         AudioManager.Instance.UnPause();

--- a/Assets/Scripts/NoteGenerator.cs
+++ b/Assets/Scripts/NoteGenerator.cs
@@ -113,21 +113,6 @@ public class NoteGenerator : MonoBehaviour
         Gen2();
     }
 
-    // 노트 생성 일시정지
-    public void PauseGen()
-    {
-        if (coGenTimer != null)
-        {
-            StopCoroutine(coGenTimer);
-            coGenTimer = null;
-        }
-        if (coReleaseTimer != null)
-        {
-            StopCoroutine(coReleaseTimer);
-            coReleaseTimer = null;
-        }
-    }
-
     // 노트 생성 중지 및 노트 Release
     public void StopGen()
     {

--- a/ProjectSettings/AudioManager.asset
+++ b/ProjectSettings/AudioManager.asset
@@ -8,12 +8,13 @@ AudioManager:
   Rolloff Scale: 1
   Doppler Factor: 1
   Default Speaker Mode: 2
-  m_SampleRate: 0
+  m_SampleRate: 44100
   m_DSPBufferSize: 1024
   m_VirtualVoiceCount: 512
   m_RealVoiceCount: 32
+  m_EnableOutputSuspension: 1
   m_SpatializerPlugin: 
   m_AmbisonicDecoderPlugin: 
   m_DisableAudio: 0
   m_VirtualizeEffects: 1
-  m_RequestedDSPBufferSize: 0
+  m_RequestedDSPBufferSize: 1024

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -227,6 +227,7 @@ QualitySettings:
     Lumin: 5
     Nintendo Switch: 5
     PS4: 5
+    Server: 0
     Stadia: 5
     Standalone: 5
     WebGL: 3


### PR DESCRIPTION
일시정지를 여러번 반복하여 누를 때, 다음사진처럼 노래가 밀리고 노트가 사라지는 현상이 나타난다.

![image](https://github.com/rhythm-gamers/rg-front-unity/assets/96125546/4d7441d2-0488-4dcc-9b69-342dbe3952da)

노트는 오디오의 재생시간을 기반으로 생성되기 때문에, 오디오가 밀리는 것이 버그의 원인이라고 확신.

하지만 유니티 상, 노래 클립의 시간 자체는 정상적으로 흐르고 있는 상황.

그렇기에, 확실하진 않지만 WebGL로 실행되면서 브라우저단에서 오디오 딜레이가 생기는 것으로 판단.

Pause 당시의 시간을 저장해두고, UnPause시에 덮어쓰니 해결.

[Fix: 일시 정지 반복 시, 오디오가 밀리는 버그 수정](https://github.com/rhythm-gamers/rg-front-unity/commit/b948bba3a3bd37c9f68e8546a147a83ce2a96b84)